### PR TITLE
`nocodes_screen_closed` action renamed to `nocodes_finished`

### DIFF
--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesEventListener.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesEventListener.kt
@@ -5,7 +5,7 @@ interface NoCodesEventListener {
     
     enum class Event(val key: String) {
         ScreenShown("nocodes_screen_shown"),
-        ScreenClosed("nocodes_screen_closed"),
+        Finished("nocodes_finished"),
         ActionStarted("nocodes_action_started"),
         ActionFinished("nocodes_action_finished"),
         ActionFailed("nocodes_action_failed"),

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesSandwich.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesSandwich.kt
@@ -138,7 +138,7 @@ class NoCodesSandwich {
             }
 
             override fun onFinished() {
-                eventListener.onNoCodesEvent(NoCodesEventListener.Event.ScreenClosed)
+                eventListener.onNoCodesEvent(NoCodesEventListener.Event.Finished)
             }
 
             override fun onScreenFailedToLoad(error: NoCodesError) {

--- a/ios/sandwich/NoCodesEventListener.swift
+++ b/ios/sandwich/NoCodesEventListener.swift
@@ -14,7 +14,7 @@ import Foundation
 
 public enum NoCodesEvent: String {
     case screenShown = "nocodes_screen_shown"
-    case screenClosed = "nocodes_screen_closed"
+    case finished = "nocodes_finished"
     case actionStarted = "nocodes_action_started"
     case actionFailed = "nocodes_action_failed"
     case actionFinished = "nocodes_action_finished"

--- a/ios/sandwich/NoCodesSandwich.swift
+++ b/ios/sandwich/NoCodesSandwich.swift
@@ -62,7 +62,7 @@ public class NoCodesSandwich: NSObject {
     @objc public func getAvailableEvents() -> [String] {
         let availableEvents: [NoCodesEvent] = [
             .screenShown,
-            .screenClosed,
+            .finished,
             .actionStarted,
             .actionFailed,
             .actionFinished,
@@ -119,7 +119,7 @@ extension NoCodesSandwich: NoCodes.Delegate {
     }
     
     public func noCodesFinished() {
-        noCodesEventListener?.noCodesDidTrigger(event: NoCodesEvent.screenClosed.rawValue, payload: nil)
+        noCodesEventListener?.noCodesDidTrigger(event: NoCodesEvent.finished.rawValue, payload: nil)
     }
     
     public func noCodesFailedToLoadScreen(error: Error?) {


### PR DESCRIPTION
Release 6.0.2