### PR TITLE
Add SPM support via Package.swift

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,3 +16,16 @@ jobs:
       - name: Validation
         run: |
           pod lib lint --allow-warnings
+
+  spm_build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4.0'
+
+      - uses: actions/checkout@v2
+      - name: Swift build (SPM)
+        run: |
+          swift build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "QonversionSandwich",
+    platforms: [
+        .iOS(.v13), .macOS(.v10_15)
+    ],
+    products: [
+        .library(
+            name: "QonversionSandwich",
+            targets: ["QonversionSandwich"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/qonversion/qonversion-ios-sdk.git", exact: "6.10.0")
+    ],
+    targets: [
+        .target(
+            name: "QonversionSandwich",
+            dependencies: [
+                .product(name: "Qonversion", package: "qonversion-ios-sdk")
+            ],
+            path: "ios/sandwich"
+        )
+    ]
+)

--- a/ios/sandwich/Mappers.swift
+++ b/ios/sandwich/Mappers.swift
@@ -75,11 +75,19 @@ extension NSError {
       }
 
       if (strCode == nil && domain == QonversionErrorDomain) {
+        #if SWIFT_PACKAGE
+        // QNUtils is internal to qonversion-ios-sdk and not exposed to SPM consumers.
+        // Keep this list in sync with QNUtils.authErrorsCodes (QNUtils.m).
+        let authErrorCodes: [Int] = [401, 402, 403]
+        let isAuthErrorCode = authErrorCodes.contains(code)
+        #else
         let authErrorCodes = QNUtils.authErrorsCodes() as? [NSNumber] ?? []
+        let isAuthErrorCode = authErrorCodes.contains { $0.intValue == code }
+        #endif
 
         if (code >= 500 && code < 600) {
           strCode = codes[Qonversion.ErrorCode.internalError.rawValue]
-        } else if (authErrorCodes.contains { $0.intValue == code }) {
+        } else if (isAuthErrorCode) {
           strCode = codes[Qonversion.ErrorCode.invalidCredentials.rawValue]
         }
       }

--- a/ios/sandwich/NoCodesMapper.swift
+++ b/ios/sandwich/NoCodesMapper.swift
@@ -1,6 +1,9 @@
 import Foundation
 #if os(iOS)
 import Qonversion
+#if SWIFT_PACKAGE
+import NoCodes
+#endif
 
 extension NoCodesAction {
     func toMap() -> BridgeData {

--- a/ios/sandwich/NoCodesSandwich.swift
+++ b/ios/sandwich/NoCodesSandwich.swift
@@ -9,6 +9,9 @@
 
 import Foundation
 import Qonversion
+#if SWIFT_PACKAGE
+import NoCodes
+#endif
 import UIKit
 
 public class NoCodesSandwich: NSObject {

--- a/ios/sandwich/QonversionSandwich.swift
+++ b/ios/sandwich/QonversionSandwich.swift
@@ -105,16 +105,24 @@ public class QonversionSandwich : NSObject {
         let timestampNumber = NSNumber(value: timestamp)
         let paymentDiscount = SKPaymentDiscount(identifier: productDiscountId, keyIdentifier: keyIdentifier, nonce: nonceUUID, signature: signature, timestamp: timestampNumber)
         
+        #if SWIFT_PACKAGE
+        // initWithProductDiscount:paymentDiscount: is internal to qonversion-ios-sdk
+        // (not in the public .h), so it is unavailable to SPM consumers.
+        let promotionalOffer = Qonversion.PromotionalOffer()
+        promotionalOffer.productDiscount = productDiscount
+        promotionalOffer.paymentDiscount = paymentDiscount
+        #else
         let promotionalOffer = Qonversion.PromotionalOffer(productDiscount: productDiscount, paymentDiscount: paymentDiscount)
+        #endif
         purchaseOptions = Qonversion.PurchaseOptions(quantity: quantity, contextKeys: contextKeys, promoOffer: promotionalOffer)
       } else {
         purchaseOptions = Qonversion.PurchaseOptions(quantity: quantity, contextKeys: contextKeys)
       }
-      
+
       Qonversion.shared().purchaseProduct(product, options: purchaseOptions, completion: purchaseCompletion)
     }
   }
-  
+
   @objc public func getPromotionalOffer(_ productId: String, productDiscountId: String, completion: @escaping BridgeCompletion) {
     if #available(iOS 12.2, macOS 10.14.4, watchOS 6.2, tvOS 12.2, visionOS 1.0, *) {
       Qonversion.shared().products { [weak self] result, err in
@@ -190,12 +198,20 @@ public class QonversionSandwich : NSObject {
         let timestampNumber = NSNumber(value: timestamp)
         let paymentDiscount = SKPaymentDiscount(identifier: productDiscountId, keyIdentifier: keyIdentifier, nonce: nonceUUID, signature: signature, timestamp: timestampNumber)
         
+        #if SWIFT_PACKAGE
+        // initWithProductDiscount:paymentDiscount: is internal to qonversion-ios-sdk
+        // (not in the public .h), so it is unavailable to SPM consumers.
+        let promotionalOffer = Qonversion.PromotionalOffer()
+        promotionalOffer.productDiscount = productDiscount
+        promotionalOffer.paymentDiscount = paymentDiscount
+        #else
         let promotionalOffer = Qonversion.PromotionalOffer(productDiscount: productDiscount, paymentDiscount: paymentDiscount)
+        #endif
         purchaseOptions = Qonversion.PurchaseOptions(quantity: quantity, contextKeys: contextKeys, promoOffer: promotionalOffer)
       } else {
         purchaseOptions = Qonversion.PurchaseOptions(quantity: quantity, contextKeys: contextKeys)
       }
-      
+
       Qonversion.shared().purchase(product, options: purchaseOptions) { purchaseResult in
         let bridgeData: [String: Any]? = purchaseResult.toMap().clearEmptyValues()
         completion(bridgeData, nil)

--- a/ios/sandwich/QonversionSandwich.swift
+++ b/ios/sandwich/QonversionSandwich.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 import Qonversion
+#if SWIFT_PACKAGE
+import QonversionSwift
+#endif
 
 public class QonversionSandwich : NSObject {
   


### PR DESCRIPTION
## Summary
- Add `Package.swift` to enable Swift Package Manager distribution for `QonversionSandwich`
- Fix module boundary issues that prevented compilation under SPM (conditional imports for `QonversionSwift` and `NoCodes`; gated handling of internal-only `QNUtils.authErrorsCodes` and `PromotionalOffer` convenience initializer)
- Backward-compatible with existing CocoaPods builds: all SPM-specific workarounds are wrapped in `#if SWIFT_PACKAGE`

## Context

Resolves https://github.com/qonversion/qonversion-ios-sdk/issues/643

Unity SDK v9.2.1 bridge files hard-depend on `@import QonversionSandwich;`. Without SPM support in sandwich-sdk, users who integrate via SPM get `Module 'QonversionSandwich' not found`.

## Changes

| File | Change |
|------|--------|
| `Package.swift` | New. Pins `qonversion-ios-sdk` to `.exact("6.10.0")` to match podspec. |
| `.gitignore` | New. Ignores `.build/`, `.swiftpm/`, `Package.resolved` (libraries should not commit resolved files - SPM ignores them from dependencies). |
| `.github/workflows/checks.yml` | Added `spm_build` job running `swift build` on macos-latest with Xcode 16.4.0. |
| `QonversionSandwich.swift` | Top-of-file: `#if SWIFT_PACKAGE import QonversionSwift`. Both `PromotionalOffer` init sites gated: SPM uses empty init + property assignment (public `productDiscount`/`paymentDiscount`); CocoaPods keeps `PromotionalOffer(productDiscount:paymentDiscount:)` convenience init (which is defined in `QONPromotionalOffer.m` but not exposed via the public header - visible inside the pod but not via SPM's public-headers bridge). |
| `Mappers.swift` | `QNUtils.authErrorsCodes()` gated under `#if SWIFT_PACKAGE`. SPM path uses inline `[401, 402, 403]` fallback with a drift-watch comment pointing at `QNUtils.m`; CocoaPods path keeps calling `QNUtils.authErrorsCodes()` unchanged. |
| `NoCodesMapper.swift` | `#if SWIFT_PACKAGE import NoCodes`. |
| `NoCodesSandwich.swift` | `#if SWIFT_PACKAGE import NoCodes`. |

## Test plan
- [x] `swift build` (SPM): clean build, no warnings introduced by this PR
- [x] `pod lib lint --allow-warnings` (CocoaPods): "QonversionSandwich passed validation"
- [x] `git diff origin/develop --stat`: 7 files, +80/-4. No podspec, no Podfile.lock, no Kotlin, no TestSwiftClass changes
- [x] `git log origin/develop..HEAD`: exactly 2 commits, no regression noise
- [x] DeferredPurchasesListener feature preserved (`qonversionDidCompleteDeferredPurchase` in `QonversionEventListener.swift`; `setDeferredPurchasesListener` + `DeferredPurchasesListener` extension in `QonversionSandwich.swift`)
- [x] Qonversion dependency stays at 6.10.0 in podspec
- [ ] Test SPM integration from a consumer project - to be automated in a follow-up, now that `spm_build` job is in place on the main workflow

Linear: SUP3-92

Generated with Claude Code