### PR TITLE
Fix sandwich 7.8.0 publish: bump no-codes to 1.8.0

### DIFF
--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.7.0'
+    ext.nocodes_version = '1.8.0'
 }
 
 plugins {


### PR DESCRIPTION
## Summary

- Bump `no-codes` dependency from `1.7.0` to `1.8.0` to fix the `compileReleaseKotlin` failure that prevented sandwich 7.8.0 from publishing to Maven Central

## Root cause

Sandwich 7.8.0 code imports `QDeferredPurchasesListener` (added in android-sdk 9.3.0), but `no-codes:1.7.0` transitively pulls in android-sdk 9.2.2 which doesn't have that class. `no-codes:1.8.0` pulls in android-sdk 9.3.0, resolving the unresolved reference.

Dependency chain before fix:
```
sandwich:7.8.0 -> no-codes:1.7.0 -> android-sdk:9.2.2 (missing QDeferredPurchasesListener)
```

After fix:
```
sandwich:7.8.0 -> no-codes:1.8.0 -> android-sdk:9.3.0 (has QDeferredPurchasesListener)
```

## Context

- Failed CI run: https://github.com/qonversion/sandwich-sdk/actions/runs/24037545623
- Downstream issue: qonversion/flutter-sdk#444 (flutter-sdk 11.6.0 references sandwich 7.8.0 which was never published)

## Test plan

- [ ] Merge, then re-trigger the 7.8.0 release publish workflow
- [ ] Verify `io.qonversion:sandwich:7.8.0` appears on Maven Central
- [ ] Verify `qonversion_flutter` 11.6.0 Android builds resolve successfully

Generated with [Claude Code](https://claude.com/claude-code)