### PR TITLE
Release 7.8.2

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  s.dependency "Qonversion", "6.10.0"
+  s.dependency "Qonversion", "6.11.0"
   s.module_name = 'QonversionSandwich'
 end

--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.8.1'
+  s.version      = '7.8.2'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.8.1",
+                versionName: "7.8.2",
         ]
     }
 

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.8.0'
+    ext.nocodes_version = '1.9.1'
 }
 
 plugins {


### PR DESCRIPTION
## Summary

Cuts sandwich 7.8.2 to propagate the SDK 9.4.1 race condition fix (SUP3-118) through to cross-platform consumers.

## Changes

- `android/build.gradle`: bump `release.versionName` from `7.8.1` to `7.8.2`
- `android/sandwich/build.gradle`: bump `ext.nocodes_version` from `1.8.0` to `1.9.1`
- `QonversionSandwich.podspec`: bump `s.version` from `7.8.1` to `7.8.2`

No source changes - version bumps only.

## Why

`sandwich:7.8.1` (current latest) still pins `no-codes:1.8.0`, which transitively pulls `io.qonversion.android.sdk:sdk:9.3.0`. That chain does not contain the SUP3-118 fix. Bumping to `no-codes:1.9.1` brings in `sdk:9.4.1` with the race-condition fix.

Resulting chain: `sandwich:7.8.2 -> no-codes:1.9.1 -> android-sdk:9.4.1`.

## Dependency

This PR depends on `io.qonversion:no-codes:1.9.1` being published to Maven Central first.
Companion PRs in `qonversion/android-sdk`: [#805](https://github.com/qonversion/android-sdk/pull/805) (develop) and [#806](https://github.com/qonversion/android-sdk/pull/806) (main).

## Release steps after merge

1. Merge to develop, then merge same branch to main
2. Push tag `7.8.2`
3. `publish_sdks.yml` workflow uploads `io.qonversion:sandwich:7.8.2` (Android) and `QonversionSandwich 7.8.2` (CocoaPods)
4. Verify on Maven Central + CocoaPods, then proceed with Unity SDK 9.5.1 PR

## Linear

[SUP3-141 - Propagate SDK 9.4.1 race condition fix to Unity SDK chain](https://linear.app/qonversion/issue/SUP3-141)
Related: [SUP3-118](https://linear.app/qonversion/issue/SUP3-118)