### PR TITLE
Release 7.8.2

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  s.dependency "Qonversion", "6.10.0"
+  s.dependency "Qonversion", "6.11.0"
   s.module_name = 'QonversionSandwich'
 end

--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.8.1'
+  s.version      = '7.8.2'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.8.1",
+                versionName: "7.8.2",
         ]
     }
 

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.8.0'
+    ext.nocodes_version = '1.9.1'
 }
 
 plugins {


### PR DESCRIPTION
## Summary

Companion PR to merge sandwich 7.8.2 into main (mirrors the auto-release-pr workflow's two-PR pattern).

After this merges, push tag `7.8.2` to trigger the publish workflow.

See companion: #314 (develop)

Depends on `io.qonversion:no-codes:1.9.1` being published first - see [qonversion/android-sdk#805](https://github.com/qonversion/android-sdk/pull/805) and [#806](https://github.com/qonversion/android-sdk/pull/806).

## Linear

[SUP3-141](https://linear.app/qonversion/issue/SUP3-141) - Propagate SDK 9.4.1 race condition fix to Unity SDK chain