### PR TITLE
Align onDeferredPurchaseCompleted param name with iOS (purchaseResult)

### DIFF
--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/QonversionEventsListener.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/QonversionEventsListener.kt
@@ -4,5 +4,5 @@ interface QonversionEventsListener {
 
     fun onEntitlementsUpdated(entitlements: BridgeData)
 
-    fun onDeferredPurchaseCompleted(transaction: BridgeData)
+    fun onDeferredPurchaseCompleted(purchaseResult: BridgeData)
 }


### PR DESCRIPTION
## Summary

Rename the supertype param from \`transaction\` to \`purchaseResult\` in \`QonversionEventsListener.onDeferredPurchaseCompleted\`. Aligns with iOS naming (\`RNQonversion.mm\` uses \`purchaseResult\`) and the param name already chosen by the override in react-native-sdk and flutter-sdk.

Without this rename, both react-native-sdk and flutter-sdk emit a Kotlin compiler warning on every build:

\`\`\`
warning: the corresponding parameter in the supertype 'QonversionEventsListener' is named 'transaction'. This may cause problems when calling this function with named arguments.
\`\`\`

(See [react-native-sdk #439](https://github.com/qonversion/react-native-sdk/issues/439) for the original report.)

## Compatibility

- The only call site inside sandwich-sdk (\`QonversionSandwich.kt:512\`) passes a positional argument, so this is purely a metadata change.
- No named-argument callers exist across the Qonversion repos (verified with \`grep -rn 'onDeferredPurchaseCompleted(transaction =' .\`).
- Java consumers (cordova-plugin, unity-sdk) do not use Kotlin named arguments and are unaffected.
- Kotlin consumers (react-native-sdk, flutter-sdk) override with \`purchaseResult\` already, so the rename eliminates their warning instead of introducing a new one.

## Follow-up after release

Once a sandwich version containing this change is published, two follow-up PRs will bump the dep:
- react-native-sdk: \`android/build.gradle\` line 83 - \`io.qonversion:sandwich:7.9.0\` -> next.
- flutter-sdk: \`android/build.gradle\` line 54 - same bump.

Single-line change, +1/-1.