### PR TITLE
Release 7.9.1 (no-codes 1.9.2)

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.9.0'
+  s.version      = '7.9.1'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.9.0",
+                versionName: "7.9.1",
         ]
     }
 

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.9.1'
+    ext.nocodes_version = '1.9.2'
 }
 
 plugins {


### PR DESCRIPTION
## Summary

Bumps sandwich to 7.9.1 to pull in `io.qonversion:no-codes:1.9.2` transitively.

Picks up the flutter-sdk#450 process-death restoration crash fix (qonversion/android-sdk#807, released as no-codes 1.9.2).

## Diff

- `android/build.gradle`: `release.versionName` 7.9.0 -> 7.9.1
- `android/sandwich/build.gradle`: `nocodes_version` 1.9.1 -> 1.9.2
- `QonversionSandwich.podspec`: `s.version` 7.9.0 -> 7.9.1 (kept in sync for parity even though this release has no iOS-side change)

## Test plan

- [ ] CI green on this branch
- [ ] Maven Central + CocoaPods publish complete after merge + tag (manual)