### PR TITLE
Fix Checks lint: use latest-stable Xcode

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: latest-stable
 
       - uses: actions/checkout@v2
       - name: Validation


### PR DESCRIPTION
The lint job pins Xcode 16.4.0, which GitHub removed from the macos-latest runners (they now carry 26.x). setup-xcode fails before pod lib lint runs, so lint is red on every PR right now (including #324).

Switches to latest-stable so it resolves whatever Xcode the runner has and won't break again on the next runner rotation. One-line CI fix, kept separate from the release work.