### PR TITLE
Fix CI: use latest-stable Xcode in checks and publish workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: latest-stable
 
       - uses: actions/checkout@v2
       - name: Validation

--- a/.github/workflows/publish_sdks.yml
+++ b/.github/workflows/publish_sdks.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: latest-stable
 
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub removed Xcode 16.4.0 from the `macos-latest` runners (they now provide 26.x), so `maxim-lobanov/setup-xcode@v1` fails with `Could not find Xcode version that satisfied version spec: '16.4.0'` in two workflows:

- **`checks.yml`** (lint) — fails before `pod lib lint`, so lint is red on every PR
- **`publish_sdks.yml`** (iOS publish) — fails before `pod trunk push`, so the iOS pod isn't published and the release run is marked failed

Both switch to `latest-stable`, which resolves whatever Xcode the runner provides and won't break again on the next runner image update.
