### PR TITLE
Add one-click release workflows (DEV-1179)

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,14 @@
+name: Publish release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish_release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') && contains(github.event.pull_request.labels.*.name, 'one-click-release')
+    uses: qonversion/shared-sdk-workflows/.github/workflows/publish_release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish_sdks.yml
+++ b/.github/workflows/publish_sdks.yml
@@ -12,11 +12,11 @@ jobs:
       run:
         working-directory: ./android
     steps:
+      # No explicit ref: on the release event the default ref is the release
+      # tag, so the published artifacts always match the released commit even
+      # if main has moved forward since the release was published.
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          ref:
-            main
 
       - name: Prepare Sonatype Gradle properties
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version part to bump'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: 'Explicit release version like 5.13.2 (overrides bump)'
+        required: false
+        type: string
+      release_notes:
+        description: 'Release notes markdown (empty — auto-generated from pull requests)'
+        required: false
+        type: string
+
+jobs:
+  release:
+    uses: qonversion/shared-sdk-workflows/.github/workflows/release.yml@main
+    with:
+      bump: ${{ inputs.bump }}
+      version: ${{ inputs.version }}
+      release_notes: ${{ inputs.release_notes }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Pilot of one-click SDK release automation ([DEV-1179](https://linear.app/qonversion/issue/DEV-1179)). Depends on qonversion/shared-sdk-workflows#1 — merge that one first.

- **release.yml** (workflow_dispatch): the whole release in one run — choose patch/minor/major (or an explicit version), optionally pass release notes; the shared workflow bumps versions, opens the release PRs, approves and merges main, and publishes the GitHub release. `Publish SDKs` then fires on `release:[released]` exactly as before.
- **publish_release.yml**: creates the GitHub release when a `one-click-release`-labeled `release/*` PR merges to main, then syncs the develop PR (restores the branch if auto-deleted — this repo has "automatically delete head branches" enabled).
- **publish_sdks.yml**: check out the release tag instead of `ref: main`, so published artifacts always match the released commit even if main moves between the release and the job start.

Old flows (manual prerelease, tag-triggered PRs, Development Build) are untouched and keep working; they are gated out of the new publish flow by the `one-click-release` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjdKcoaoecn6TKWmnUZzji
