### PR TITLE
Add one-click release workflows — main mirror (DEV-1179)

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,14 @@
+name: Publish release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish_release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') && contains(github.event.pull_request.labels.*.name, 'one-click-release')
+    uses: qonversion/shared-sdk-workflows/.github/workflows/publish_release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish_sdks.yml
+++ b/.github/workflows/publish_sdks.yml
@@ -12,11 +12,11 @@ jobs:
       run:
         working-directory: ./android
     steps:
+      # No explicit ref: on the release event the default ref is the release
+      # tag, so the published artifacts always match the released commit even
+      # if main has moved forward since the release was published.
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          ref:
-            main
 
       - name: Prepare Sonatype Gradle properties
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version part to bump'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: 'Explicit release version like 5.13.2 (overrides bump)'
+        required: false
+        type: string
+      release_notes:
+        description: 'Release notes markdown (empty — auto-generated from pull requests)'
+        required: false
+        type: string
+
+jobs:
+  release:
+    uses: qonversion/shared-sdk-workflows/.github/workflows/release.yml@main
+    with:
+      bump: ${{ inputs.bump }}
+      version: ${{ inputs.version }}
+      release_notes: ${{ inputs.release_notes }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Same change as the develop PR (cherry-pick), targeted at `main` directly: `main` is the default branch, and a `workflow_dispatch` workflow must exist on the default branch to be runnable. Without this, the new Release workflow would only become dispatchable after the next regular release merges develop into main.

Part of [DEV-1179](https://linear.app/qonversion/issue/DEV-1179). See the develop PR for the full description. Content is identical, so the next release diff between develop and main stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjdKcoaoecn6TKWmnUZzji
