### PR TITLE
Revert release 7.9.5 version bump (main)

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.9.5'
+  s.version      = '7.9.4'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.9.5",
+                versionName: "7.9.4",
         ]
     }
 

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,7 +5,7 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000245489">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000285">
         
       </testcase>
     


### PR DESCRIPTION
Counterpart of #335 for main. Rollback of the 7.9.5 pilot bump to rerun the one-click release from scratch with the fixed workflow (DEV-1179). No tag/release existed, nothing was published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjdKcoaoecn6TKWmnUZzji