### PR TITLE
Bridge No-Codes loadScreen, defaultVariables and custom actions from native SDKs (DEV-1187)

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  s.dependency "Qonversion", "6.11.0"
+  s.dependency "Qonversion", "6.13.0"
   s.module_name = 'QonversionSandwich'
 end

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.9.3'
+    ext.nocodes_version = '1.10.0'
 }
 
 plugins {

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
@@ -30,6 +30,9 @@ import com.qonversion.android.sdk.dto.products.QProductStoreDetails
 import com.qonversion.android.sdk.dto.properties.QUserProperties
 import com.qonversion.android.sdk.dto.properties.QUserProperty
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QNoCodeScreen
+import io.qonversion.nocodes.dto.QScreenVariable
+import io.qonversion.nocodes.dto.QScreenVariableValue
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.dto.QScreenPresentationConfig
 import io.qonversion.nocodes.dto.QScreenPresentationStyle
@@ -330,6 +333,51 @@ fun NoCodesError.toMap(): BridgeData {
         "description" to details,
         "qonversionError" to qonversionError?.toMap()
     )
+}
+
+fun NoCodesError.toSandwichError(): SandwichError {
+    return SandwichError(
+        code.toString(),
+        code.defaultMessage,
+        details ?: ""
+    )
+}
+
+fun QNoCodeScreen.toMap(): BridgeData {
+    return mapOf(
+        "id" to id,
+        "contextKey" to contextKey,
+        "defaultSelectedProductId" to defaultSelectedProductId,
+        "defaultVariables" to defaultVariables.map { it.toMap() }
+    )
+}
+
+fun QScreenVariable.toMap(): BridgeData {
+    return mapOf(
+        "kind" to kind.toFormattedString(),
+        "key" to key,
+        "type" to type,
+        "value" to value.toBridgeValue(),
+        "stringValue" to value.asString()
+    )
+}
+
+fun QScreenVariable.Kind.toFormattedString(): String {
+    return when (this) {
+        QScreenVariable.Kind.Custom -> "custom"
+        QScreenVariable.Kind.Product -> "product"
+        QScreenVariable.Kind.SelectedProduct -> "selected_product"
+        else -> "unknown"
+    }
+}
+
+fun QScreenVariableValue.toBridgeValue(): Any? {
+    return when (this) {
+        is QScreenVariableValue.Bool -> value
+        is QScreenVariableValue.Str -> value
+        is QScreenVariableValue.Num -> value
+        QScreenVariableValue.None -> null
+    }
 }
 
 // region PurchaseResult Mappers

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
@@ -339,7 +339,7 @@ fun NoCodesError.toSandwichError(): SandwichError {
     return SandwichError(
         code.toString(),
         code.defaultMessage,
-        details ?: ""
+        details ?: qonversionError?.let { "${it.description}. ${it.additionalMessage}" } ?: ""
     )
 }
 

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesEventListener.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesEventListener.kt
@@ -9,6 +9,7 @@ interface NoCodesEventListener {
         ActionStarted("nocodes_action_started"),
         ActionFinished("nocodes_action_finished"),
         ActionFailed("nocodes_action_failed"),
-        ScreenFailedToLoad("nocodes_screen_failed_to_load")
+        ScreenFailedToLoad("nocodes_screen_failed_to_load"),
+        CustomAction("nocodes_custom_action")
     }
 }

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesSandwich.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/NoCodesSandwich.kt
@@ -8,7 +8,9 @@ import io.qonversion.nocodes.dto.LogLevel
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
+import io.qonversion.nocodes.interfaces.NoCodesScreenLoadCallback
 import io.qonversion.nocodes.interfaces.ScreenCustomizationDelegate
+import io.qonversion.nocodes.dto.QNoCodeScreen
 import io.qonversion.nocodes.dto.QScreenPresentationConfig
 import io.qonversion.nocodes.dto.QAction
 import io.qonversion.nocodes.error.NoCodesError
@@ -145,6 +147,18 @@ class NoCodesSandwich {
         NoCodes.shared.showScreen(contextKey)
     }
 
+    fun loadScreen(contextKey: String, resultListener: ResultListener) {
+        NoCodes.shared.loadScreen(contextKey, object : NoCodesScreenLoadCallback {
+            override fun onSuccess(screen: QNoCodeScreen) {
+                resultListener.onSuccess(screen.toMap())
+            }
+
+            override fun onError(error: NoCodesError) {
+                resultListener.onError(error.toSandwichError())
+            }
+        })
+    }
+
     fun close() {
         NoCodes.shared.close()
     }
@@ -216,6 +230,11 @@ class NoCodesSandwich {
 
             override fun onActionFinishedExecuting(action: QAction) {
                 eventListener.onNoCodesEvent(NoCodesEventListener.Event.ActionFinished, action.toMap())
+            }
+
+            override fun onCustomAction(value: String) {
+                val payload = mapOf("value" to value)
+                eventListener.onNoCodesEvent(NoCodesEventListener.Event.CustomAction, payload)
             }
 
             override fun onFinished() {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Qonversion (6.9.0):
-    - Qonversion/Main (= 6.9.0)
-  - Qonversion/Main (6.9.0)
-  - QonversionSandwich (7.7.0):
-    - Qonversion (~> 6.9)
+  - Qonversion (6.13.0):
+    - Qonversion/Main (= 6.13.0)
+  - Qonversion/Main (6.13.0)
+  - QonversionSandwich (7.9.5):
+    - Qonversion (= 6.13.0)
 
 DEPENDENCIES:
   - QonversionSandwich (from `../`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Qonversion: bcd154ecd6c0f323971dbddbb71d2e9257b171d1
-  QonversionSandwich: e69816923035948e3f2849647a612e0161c97b40
+  Qonversion: 7c4ffeb6e6b23a248d370c47d82347fd6a18d175
+  QonversionSandwich: 511290b359d9924d395bb8d086ff46c558def70f
 
 PODFILE CHECKSUM: ac49d3b542908b3399ace18f7369621020b752c0
 

--- a/ios/sandwich/NoCodesEventListener.swift
+++ b/ios/sandwich/NoCodesEventListener.swift
@@ -19,4 +19,5 @@ public enum NoCodesEvent: String {
     case actionFailed = "nocodes_action_failed"
     case actionFinished = "nocodes_action_finished"
     case screenFailedToLoad = "nocodes_screen_failed_to_load"
+    case customAction = "nocodes_custom_action"
 }

--- a/ios/sandwich/NoCodesMapper.swift
+++ b/ios/sandwich/NoCodesMapper.swift
@@ -61,25 +61,32 @@ extension Dictionary where Key == String, Value == Any {
 
 extension NoCodesError {
 
+  private static let codeStrings = [
+    NoCodesErrorType.unknown: "Unknown",
+    NoCodesErrorType.`internal`: "Internal",
+    NoCodesErrorType.authorizationFailed: "AuthorizationFailed",
+    NoCodesErrorType.critical: "Critical",
+    NoCodesErrorType.invalidRequest: "BadNetworkRequest",
+    NoCodesErrorType.invalidResponse: "BadResponse",
+    NoCodesErrorType.productNotFound: "ProductNotFound",
+    NoCodesErrorType.productsLoadingFailed: "ProductsLoadingFailed",
+    NoCodesErrorType.rateLimitExceeded: "RateLimitExceeded",
+    NoCodesErrorType.screenNotFound: "ScreenNotFound",
+    NoCodesErrorType.screenLoadingFailed: "ScreenLoadingFailed",
+    NoCodesErrorType.sdkInitializationError: "SDKInitializationError",
+    NoCodesErrorType.clientError: "ClientError"
+  ]
+
+  private var qonversionNSError: NSError? {
+    guard let nsError = error as? NSError, nsError.domain == QonversionErrorDomain else { return nil }
+    return nsError
+  }
+
   func toMap() -> BridgeData {
-    let codes = [
-      NoCodesErrorType.unknown: "Unknown",
-      NoCodesErrorType.`internal`: "Internal",
-      NoCodesErrorType.authorizationFailed: "AuthorizationFailed",
-      NoCodesErrorType.critical: "Critical",
-      NoCodesErrorType.invalidRequest: "BadNetworkRequest",
-      NoCodesErrorType.invalidResponse: "BadResponse",
-      NoCodesErrorType.productNotFound: "ProductNotFound",
-      NoCodesErrorType.productsLoadingFailed: "ProductsLoadingFailed",
-      NoCodesErrorType.rateLimitExceeded: "RateLimitExceeded",
-      NoCodesErrorType.screenLoadingFailed: "ScreenLoadingFailed",
-      NoCodesErrorType.sdkInitializationError: "SDKInitializationError"
-    ]
-    
-    var code = codes[type]
+    var code = NoCodesError.codeStrings[type]
     var errorData: BridgeData? = nil
-    
-    if let nsError = error as? NSError, nsError.domain == QonversionErrorDomain {
+
+    if let nsError = qonversionNSError {
       code = "QonversionError"
       errorData = nsError.toMap()
     }
@@ -90,6 +97,50 @@ extension NoCodesError {
       "additionalMessage": additionalInfo?.map { "\($0.key): \($0.value)" }.joined(separator: ", ") ?? "",
       "qonversionError": errorData,
     ]
+  }
+
+  func toSandwichError() -> SandwichError {
+    let code = qonversionNSError == nil ? NoCodesError.codeStrings[type] ?? "Unknown" : "QonversionError"
+    return SandwichError(
+      code: code,
+      domain: "NoCodes",
+      details: message,
+      additionalMessage: additionalInfo?.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+    )
+  }
+}
+
+extension NoCodesScreen {
+  func toMap() -> BridgeData {
+    return [
+      "id": id,
+      "contextKey": contextKey,
+      "defaultSelectedProductId": defaultSelectedProductId,
+      "defaultVariables": defaultVariables.map { $0.toMap() }
+    ]
+  }
+}
+
+extension NoCodesScreenVariable {
+  func toMap() -> BridgeData {
+    return [
+      "kind": kind.rawValue,
+      "key": key,
+      "type": type,
+      "value": value.bridgeValue,
+      "stringValue": value.stringValue
+    ]
+  }
+}
+
+extension NoCodesScreenVariableValue {
+  var bridgeValue: Any? {
+    switch self {
+    case .bool(let boolValue): return boolValue
+    case .string(let stringValue): return stringValue
+    case .number(let numberValue): return numberValue
+    case .none: return nil
+    }
   }
 }
 

--- a/ios/sandwich/NoCodesSandwich.swift
+++ b/ios/sandwich/NoCodesSandwich.swift
@@ -73,7 +73,20 @@ public class NoCodesSandwich: NSObject {
         }
         NoCodes.shared.showScreen(withContextKey: contextKey)
     }
-    
+
+    @objc public func loadScreen(_ contextKey: String, completion: @escaping BridgeCompletion) {
+        Task { @MainActor in
+            do {
+                let screen = try await NoCodes.shared.loadScreen(withContextKey: contextKey)
+                completion(screen.toMap().clearEmptyValues(), nil)
+            } catch let error as NoCodesError {
+                completion(nil, error.toSandwichError())
+            } catch {
+                completion(nil, (error as NSError).toSandwichError())
+            }
+        }
+    }
+
     @MainActor @objc public func close() {
         NoCodes.shared.close()
     }
@@ -107,7 +120,8 @@ public class NoCodesSandwich: NSObject {
             .actionStarted,
             .actionFailed,
             .actionFinished,
-            .screenFailedToLoad
+            .screenFailedToLoad,
+            .customAction
         ]
         
         return availableEvents.map { $0.rawValue }
@@ -192,7 +206,12 @@ extension NoCodesSandwich: NoCodesDelegate {
         let payload: BridgeData = action.toMap()
         noCodesEventListener?.noCodesDidTrigger(event: NoCodesEvent.actionFinished.rawValue, payload: payload.clearEmptyValues())
     }
-    
+
+    public func noCodesReceivedCustomAction(value: String) {
+        let payload: BridgeData = ["value": value]
+        noCodesEventListener?.noCodesDidTrigger(event: NoCodesEvent.customAction.rawValue, payload: payload.clearEmptyValues())
+    }
+
     public func noCodesFinished() {
         noCodesEventListener?.noCodesDidTrigger(event: NoCodesEvent.finished.rawValue, payload: nil)
     }


### PR DESCRIPTION
Brings the No-Codes API shipped in native **iOS 6.13.0** / **Android nocodes 1.10.0** into the sandwich layer.

[DEV-1187](https://linear.app/qonversion/issue/DEV-1187/sandwich-bridge-no-codes-loadscreen-defaultvariables-and-custom)

## Changes

**Native dependency bumps** (required: `noCodesReceivedCustomAction` is a new required protocol method on iOS — sandwich does not compile against 6.13.0 without implementing it)
- podspec: `Qonversion` 6.11.0 → **6.13.0** (+ Podfile.lock)
- gradle: `nocodes_version` 1.9.3 → **1.10.0**

**New API**
- `loadScreen(contextKey)` — load-before-present bridge (iOS `BridgeCompletion`, Android `ResultListener`). Returns the screen map without HTML (content stays internal to the natives; presenting stays on `showScreen(contextKey)`, served from cache):
  ```json
  {
    "id": "...", "contextKey": "...",
    "defaultSelectedProductId": "main",
    "defaultVariables": [
      {"kind": "custom|product|selected_product|unknown", "key": "...", "type": "string|boolean|number", "value": "<typed>", "stringValue": "..."}
    ]
  }
  ```
- New `nocodes_custom_action` event (payload `{value}`) wired from the new delegate methods, registered in `getAvailableEvents` (iOS).
- `NoCodesError.toSandwichError()` on both platforms; iOS code mapping extended with `screenNotFound`/`clientError` (present in the native enum, missing in sandwich).

## Verification
- Android: `:sandwich:compileReleaseKotlin` ✅
- iOS: Sample scheme `xcodebuild` ✅, `pod lib lint --allow-warnings` (the CI gate) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn