### PR TITLE
Publish an empty javadoc jar instead of the crashing AGP javadoc generation (DEV-1187)

### DIFF
--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -49,3 +49,12 @@ dependencies {
 }
 
 apply from: "../scripts/maven-release.gradle"
+
+// AGP's javadoc generation (JavaDocGenerationTask) fails with "PermittedSubclasses
+// requires ASM9" on sealed classes coming from binary dependencies (no-codes 1.10.0+),
+// so skip it; maven-release.gradle attaches an empty javadoc jar instead — Maven Central
+// only checks its presence. Configured here and not in the applied script because Groovy
+// resolves constructor calls at compile time, and script plugins don't see plugin classes.
+mavenPublishing {
+    configure(new com.vanniktech.maven.publish.AndroidSingleVariantLibrary("release", true, false))
+}

--- a/android/scripts/maven-release.gradle
+++ b/android/scripts/maven-release.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
+// Empty javadoc jar replacing the disabled AGP javadoc generation (see sandwich/build.gradle).
+def emptyJavadocJar = tasks.register("emptyJavadocJar", Jar) {
+    archiveClassifier = "javadoc"
+}
+
 afterEvaluate {
     mavenPublishing {
         coordinates(PUBLISH_GROUP_ID, PUBLISH_ARTIFACT_ID, android.defaultConfig.versionName)
@@ -28,5 +33,9 @@ afterEvaluate {
                 developerConnection = POM_SCM_DEV_CONNECTION
             }
         }
+    }
+
+    publishing.publications.withType(MavenPublication).configureEach {
+        artifact(emptyJavadocJar)
     }
 }


### PR DESCRIPTION
Unblocks Android publishing to Maven Central: the 7.10.0 `Publish SDKs` run failed in `:sandwich:javaDocReleaseGeneration` with `PermittedSubclasses requires ASM9` — AGP's bundled Dokka/ASM cannot read sealed classes from the **no-codes 1.10.0 binary dependency** (`QScreenVariableValue`, JVM 17 target). Reproduced locally; bumping AGP to 8.13.2 does not help (same bundled Dokka), so the javadoc task is disabled via `AndroidSingleVariantLibrary("release", sourcesJar = true, publishJavadocJar = false)` and an **empty javadoc jar** is attached instead — Maven Central only validates its presence (their sanctioned workaround).

State: CocoaPods **7.10.0 published**, Maven Central — not (nothing to roll back). After merge: roll-forward release **7.10.1**, cross-platforms will pin it.

Verification: `:sandwich:publishToMavenLocal` ✅ — full artifact set (`aar`, `sources.jar` with content, empty `javadoc.jar`, `pom`, `module`), `javaDocReleaseGeneration` no longer invoked; signing picks up the extra artifact (fails locally only on absent GPG keys, which CI injects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn