### PR TITLE
Release 7.10.1

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.10.0'
+  s.version      = '7.10.1'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.10.0",
+                versionName: "7.10.1",
         ]
     }
 

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -49,3 +49,12 @@ dependencies {
 }
 
 apply from: "../scripts/maven-release.gradle"
+
+// AGP's javadoc generation (JavaDocGenerationTask) fails with "PermittedSubclasses
+// requires ASM9" on sealed classes coming from binary dependencies (no-codes 1.10.0+),
+// so skip it; maven-release.gradle attaches an empty javadoc jar instead — Maven Central
+// only checks its presence. Configured here and not in the applied script because Groovy
+// resolves constructor calls at compile time, and script plugins don't see plugin classes.
+mavenPublishing {
+    configure(new com.vanniktech.maven.publish.AndroidSingleVariantLibrary("release", true, false))
+}

--- a/android/scripts/maven-release.gradle
+++ b/android/scripts/maven-release.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'com.vanniktech.maven.publish'
 
+// Empty javadoc jar replacing the disabled AGP javadoc generation (see sandwich/build.gradle).
+def emptyJavadocJar = tasks.register("emptyJavadocJar", Jar) {
+    archiveClassifier = "javadoc"
+}
+
 afterEvaluate {
     mavenPublishing {
         coordinates(PUBLISH_GROUP_ID, PUBLISH_ARTIFACT_ID, android.defaultConfig.versionName)
@@ -28,5 +33,9 @@ afterEvaluate {
                 developerConnection = POM_SCM_DEV_CONNECTION
             }
         }
+    }
+
+    publishing.publications.withType(MavenPublication).configureEach {
+        artifact(emptyJavadocJar)
     }
 }

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,7 +5,7 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000313698">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000251031">
         
       </testcase>
     


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## What's New

— No-Codes: new `loadScreen(contextKey)` bridge method — loads a screen without presenting it and returns its data (id, context key, typed default variables, default selected product id)
— No-Codes: new `nocodes_custom_action` event delivering custom builder actions with their `value` payload
— No-Codes: support for custom purchase loaders — if one is set in the builder, the SDK won't show the native spinner
— No-Codes: fixed original error details being lost when wrapping client errors
— Updated native SDKs: iOS Qonversion 6.13.0, Android No-Codes 1.10.0
— Fixed publishing the Android artifact to Maven Central (7.10.0 reached CocoaPods only — this release delivers the same content to both registries)
<!-- release-notes:end -->
