### PR TITLE
DEV-1215: bridge purchaseOptionId in QProduct.toMap

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  s.dependency "Qonversion", "6.13.0"
+  s.dependency "Qonversion", "6.13.1"
   s.module_name = 'QonversionSandwich'
 end

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.nocodes_version = '1.10.0'
+    ext.nocodes_version = '1.11.0'
 }
 
 plugins {

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
@@ -128,6 +128,7 @@ fun QProductInAppDetails.toMap(): BridgeData {
 fun QProductStoreDetails.toMap(): BridgeData {
     return mapOf(
         "basePlanId" to basePlanId,
+        "purchaseOptionId" to purchaseOptionId,
         "productId" to productId,
         "name" to name,
         "title" to title,

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
@@ -54,6 +54,7 @@ fun QProduct.toMap(): BridgeData {
         "id" to qonversionId,
         "storeId" to storeId,
         "basePlanId" to basePlanId,
+        "purchaseOptionId" to purchaseOptionId,
         "type" to type.name,
         "subscriptionPeriod" to subscriptionPeriod?.toMap(),
         "trialPeriod" to trialPeriod?.toMap(),


### PR DESCRIPTION
Issue: [DEV-1215](https://linear.app/qonversion/issue/DEV-1215)

Emit the new `purchaseOptionId` field so cross-platform wrappers receive the one-time purchase option. With the native split (android-sdk #847), `basePlanId` is `null` for one-time products, so without this the option value would be dropped at the bridge. Mirrors the existing `basePlanId` entry.

**Depends on the android-sdk version that exposes `QProduct.purchaseOptionId`** (DEV-1215 native, android-sdk #847) — bump the no-codes/android-sdk dependency before this compiles/releases.

Chain: native → **sandwich** → wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)