### PR TITLE
Release 7.12.0

### DIFF
--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.11.0'
+  s.version      = '7.12.0'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.11.0",
+                versionName: "7.12.0",
         ]
     }
 

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,7 +5,7 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000218054">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000266178">
         
       </testcase>
     


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New bridge method `invalidateRemoteConfigsCache` (Android + iOS) — passes through to the new native API. It performs no network request and has no callback: it marks the remote configs cache stale so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. An in-flight `remoteConfig` load is re-issued once so its waiting callbacks receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `remoteConfigList` completes with the evaluation it started with. Threading: on iOS call it on the same queue as the other Qonversion calls; on Android any thread is safe (#355).

## Dependencies

* Android: native SDK pinned directly to [9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) (no-codes stays 1.11.0; Gradle resolves to the higher direct version).
* iOS: `Qonversion` pod `6.13.1 -> 6.14.0` ([release](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0)). Note for wrapper release notes: the pod pin is exact, so apps that also declare `Qonversion` directly must move to 6.14.0.

Native highlights bridged by this release: automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).
<!-- release-notes:end -->
