### PR TITLE
feat: bridge frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,21 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  android-unit-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./android
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - name: Native frozen assignment bridge contract
+        run: ./gradlew :sandwich:testDebugUnitTest
+
   lint:
     runs-on: macos-latest
 
@@ -12,7 +27,9 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Frozen assignment bridge contract
+        run: python3 scripts/tests/test_frozen_mapper_contract.py
       - name: Validation
         run: |
           pod lib lint --allow-warnings

--- a/.github/workflows/publish_sdks.yml
+++ b/.github/workflows/publish_sdks.yml
@@ -16,7 +16,16 @@ jobs:
       # tag, so the published artifacts always match the released commit even
       # if main has moved forward since the release was published.
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Verify Android bridge before publishing
+        run: ./gradlew :sandwich:testDebugUnitTest
 
       - name: Prepare Sonatype Gradle properties
         run: |
@@ -41,7 +50,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: CocoaPods Release
         run: pod trunk push --allow-warnings QonversionSandwich.podspec

--- a/.github/workflows/publish_sdks.yml
+++ b/.github/workflows/publish_sdks.yml
@@ -32,11 +32,13 @@ jobs:
           mkdir -p ~/.gradle
           echo "${{ secrets.SONATYPE_GPG_FILE }}" > key.gpg.asc
           gpg -d --passphrase "${{ secrets.SONATYPE_GPG_PASSPHRASE }}" --batch "key.gpg.asc" > "$HOME/.gradle/key.gpg"
-          echo "signing.keyId=${{ secrets.SONATYPE_GPG_ID }}" >> ~/.gradle/gradle.properties
-          echo "signing.password=${{ secrets.SONATYPE_GPG_PASSWORD }}" >> ~/.gradle/gradle.properties
-          echo "signing.secretKeyRingFile=$HOME/.gradle/key.gpg" >> ~/.gradle/gradle.properties
-          echo "mavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }}" >> ~/.gradle/gradle.properties
-          echo "mavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}" >> ~/.gradle/gradle.properties
+          {
+            echo "signing.keyId=${{ secrets.SONATYPE_GPG_ID }}"
+            echo "signing.password=${{ secrets.SONATYPE_GPG_PASSWORD }}"
+            echo "signing.secretKeyRingFile=$HOME/.gradle/key.gpg"
+            echo "mavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }}"
+            echo "mavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
+          } >> ~/.gradle/gradle.properties
 
       - name: Publish to MavenCentral
         run: ./gradlew :sandwich:publishAndReleaseToMavenCentral
@@ -51,6 +53,9 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Verify iOS frozen assignment bridge
+        run: python3 scripts/tests/test_frozen_mapper_contract.py
 
       - name: CocoaPods Release
         run: pod trunk push --allow-warnings QonversionSandwich.podspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+__pycache__/
+*.py[cod]

--- a/FROZEN_ASSIGNMENT_RELEASE.md
+++ b/FROZEN_ASSIGNMENT_RELEASE.md
@@ -1,10 +1,12 @@
 # Frozen assignment bridge release fence
 
-This change is intentionally release-ordered:
+This change is intentionally release-ordered because the native SDKs parse the
+backend assignment value before Sandwich receives it:
 
 1. Publish Android SDK `9.8.0` and iOS SDK `6.15.0` with the native `Frozen`
    assignment enum.
-2. Merge this change and publish Sandwich `7.13.0`.
+2. Publish Sandwich `7.13.0`, which requires those native versions and maps
+   `Frozen` to the cross-platform `"frozen"` value.
 3. Upgrade React Native, Flutter, Cordova, Capacitor and Unity to Sandwich
    `7.13.0`.
 

--- a/FROZEN_ASSIGNMENT_RELEASE.md
+++ b/FROZEN_ASSIGNMENT_RELEASE.md
@@ -1,0 +1,12 @@
+# Frozen assignment bridge release fence
+
+This change is intentionally release-ordered:
+
+1. Publish Android SDK `9.8.0` and iOS SDK `6.15.0` with the native `Frozen`
+   assignment enum.
+2. Merge this change and publish Sandwich `7.13.0`.
+3. Upgrade React Native, Flutter, Cordova, Capacitor and Unity to Sandwich
+   `7.13.0`.
+
+Until all three steps are published and present in the production compatibility
+matrix, Configurator's type-3 write gate remains fail-closed.

--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'QonversionSandwich'
-  s.version      = '7.12.0'
+  s.version      = '7.13.0'
   s.summary      = 'qonversion.io'
   s.swift_version = '5.0'
   s.description  = <<-DESC

--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  s.dependency "Qonversion", "6.14.0"
+  # Frozen assignment provenance is provided by the next native feature
+  # release. Merge only after Qonversion 6.15.0 is available on CocoaPods.
+  s.dependency "Qonversion", "6.15.0"
   s.module_name = 'QonversionSandwich'
 end

--- a/QonversionSandwich.podspec
+++ b/QonversionSandwich.podspec
@@ -16,8 +16,7 @@ Pod::Spec.new do |s|
     "osx" => "10.15"
   }
   s.source_files = 'ios/sandwich/**/*.{h,m,swift}'
-  # Frozen assignment provenance is provided by the next native feature
-  # release. Merge only after Qonversion 6.15.0 is available on CocoaPods.
+  # The native mapper must preserve `frozen` before Sandwich can bridge it.
   s.dependency "Qonversion", "6.15.0"
   s.module_name = 'QonversionSandwich'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         release = [
-                versionName: "7.12.0",
+                versionName: "7.13.0",
         ]
     }
 

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -5,7 +5,9 @@ buildscript {
     // no-codes' transitive pin was the anomaly. Keep this at >= the version
     // no-codes was built against (1.11.0 -> sdk 9.6.0); Gradle resolves to
     // the higher of the two.
-    ext.qonversion_version = '9.7.0'
+    // Frozen assignment provenance was added in the next native feature
+    // release. This PR must merge only after Android SDK 9.8.0 is published.
+    ext.qonversion_version = '9.8.0'
 }
 
 plugins {
@@ -53,6 +55,7 @@ dependencies {
     api "io.qonversion.android.sdk:sdk:$qonversion_version"
     api "io.qonversion:no-codes:$nocodes_version"
     implementation 'androidx.preference:preference:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 apply from: "../scripts/maven-release.gradle"

--- a/android/sandwich/build.gradle
+++ b/android/sandwich/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     // no-codes' transitive pin was the anomaly. Keep this at >= the version
     // no-codes was built against (1.11.0 -> sdk 9.6.0); Gradle resolves to
     // the higher of the two.
-    // Frozen assignment provenance was added in the next native feature
-    // release. This PR must merge only after Android SDK 9.8.0 is published.
+    // The native mapper must preserve `frozen` before Sandwich can bridge it.
     ext.qonversion_version = '9.8.0'
 }
 

--- a/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
+++ b/android/sandwich/src/main/kotlin/io/qonversion/sandwich/Mappers.kt
@@ -290,9 +290,14 @@ fun QRemoteConfigurationSourceType.toFormattedString(): String {
 }
 
 fun QRemoteConfigurationAssignmentType.toFormattedString(): String {
-    return when (this) {
-        QRemoteConfigurationAssignmentType.Auto -> "auto"
-        QRemoteConfigurationAssignmentType.Manual -> "manual"
+    return remoteConfigurationAssignmentTypeNameToFormattedString(name)
+}
+
+internal fun remoteConfigurationAssignmentTypeNameToFormattedString(name: String): String {
+    return when (name.lowercase()) {
+        "auto" -> "auto"
+        "manual" -> "manual"
+        "frozen" -> "frozen"
         else -> "unknown"
     }
 }

--- a/android/sandwich/src/test/kotlin/io/qonversion/sandwich/RemoteConfigurationAssignmentTypeMapperTest.kt
+++ b/android/sandwich/src/test/kotlin/io/qonversion/sandwich/RemoteConfigurationAssignmentTypeMapperTest.kt
@@ -1,0 +1,14 @@
+package io.qonversion.sandwich
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RemoteConfigurationAssignmentTypeMapperTest {
+    @Test
+    fun `bridge preserves frozen and fails safe for future values`() {
+        assertEquals("auto", remoteConfigurationAssignmentTypeNameToFormattedString("Auto"))
+        assertEquals("manual", remoteConfigurationAssignmentTypeNameToFormattedString("Manual"))
+        assertEquals("frozen", remoteConfigurationAssignmentTypeNameToFormattedString("Frozen"))
+        assertEquals("unknown", remoteConfigurationAssignmentTypeNameToFormattedString("Future"))
+    }
+}

--- a/ios/sandwich/Mappers.swift
+++ b/ios/sandwich/Mappers.swift
@@ -661,11 +661,15 @@ extension Qonversion.RemoteConfigurationSourceType {
 
 extension Qonversion.RemoteConfigurationAssignmentType {
   func toString() -> String {
-    switch self {
-    case .auto:
+    // Use the resilient case name so a newly added native enum value is not
+    // collapsed by a Sandwich binary compiled before that case existed.
+    switch String(describing: self).lowercased() {
+    case "auto":
       return "auto"
-    case .manual:
+    case "manual":
       return "manual"
+    case "frozen":
+      return "frozen"
     default:
       return "unknown"
     }

--- a/ios/sandwich/Mappers.swift
+++ b/ios/sandwich/Mappers.swift
@@ -661,16 +661,18 @@ extension Qonversion.RemoteConfigurationSourceType {
 
 extension Qonversion.RemoteConfigurationAssignmentType {
   func toString() -> String {
-    // Use the resilient case name so a newly added native enum value is not
-    // collapsed by a Sandwich binary compiled before that case existed.
-    switch String(describing: self).lowercased() {
-    case "auto":
+    // This is imported from Objective-C NS_ENUM. String(describing:) renders
+    // its raw-value wrapper, not the case name, so map cases explicitly.
+    switch self {
+    case .auto:
       return "auto"
-    case "manual":
+    case .manual:
       return "manual"
-    case "frozen":
+    case .frozen:
       return "frozen"
-    default:
+    case .unknown:
+      return "unknown"
+    @unknown default:
       return "unknown"
     }
   }

--- a/ios/sandwich/Mappers.swift
+++ b/ios/sandwich/Mappers.swift
@@ -661,8 +661,6 @@ extension Qonversion.RemoteConfigurationSourceType {
 
 extension Qonversion.RemoteConfigurationAssignmentType {
   func toString() -> String {
-    // This is imported from Objective-C NS_ENUM. String(describing:) renders
-    // its raw-value wrapper, not the case name, so map cases explicitly.
     switch self {
     case .auto:
       return "auto"

--- a/scripts/tests/test_frozen_mapper_contract.py
+++ b/scripts/tests/test_frozen_mapper_contract.py
@@ -6,8 +6,13 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class FrozenMapperContractTest(unittest.TestCase):
-    def test_objc_enum_is_mapped_by_cases_not_description(self) -> None:
+    def test_frozen_mapper_and_release_fence_require_capable_native_sdks(self) -> None:
         source = (ROOT / "ios" / "sandwich" / "Mappers.swift").read_text()
+        podspec = (ROOT / "QonversionSandwich.podspec").read_text()
+        gradle = (ROOT / "android" / "sandwich" / "build.gradle").read_text()
+        release = (ROOT / "FROZEN_ASSIGNMENT_RELEASE.md").read_text()
+        publish = (ROOT / ".github" / "workflows" / "publish_sdks.yml").read_text()
+
         self.assertNotIn("String(describing: self)", source)
         for case, value in (
             (".auto", '"auto"'),
@@ -17,6 +22,15 @@ class FrozenMapperContractTest(unittest.TestCase):
         ):
             self.assertIn(f"case {case}:", source)
             self.assertIn(f"return {value}", source)
+        self.assertIn("@unknown default:", source)
+
+        self.assertIn('s.dependency "Qonversion", "6.15.0"', podspec)
+        self.assertIn("ext.qonversion_version = '9.8.0'", gradle)
+        self.assertLess(release.index("Android SDK `9.8.0`"), release.index("Sandwich `7.13.0`"))
+        self.assertLess(
+            publish.index("python3 scripts/tests/test_frozen_mapper_contract.py"),
+            publish.index("pod trunk push"),
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_frozen_mapper_contract.py
+++ b/scripts/tests/test_frozen_mapper_contract.py
@@ -1,0 +1,23 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class FrozenMapperContractTest(unittest.TestCase):
+    def test_objc_enum_is_mapped_by_cases_not_description(self) -> None:
+        source = (ROOT / "ios" / "sandwich" / "Mappers.swift").read_text()
+        self.assertNotIn("String(describing: self)", source)
+        for case, value in (
+            (".auto", '"auto"'),
+            (".manual", '"manual"'),
+            (".frozen", '"frozen"'),
+            (".unknown", '"unknown"'),
+        ):
+            self.assertIn(f"case {case}:", source)
+            self.assertIn(f"return {value}", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Preserves the native `frozen` assignment type across both Sandwich bridges and makes the mapping a release-blocking contract.

## Strict release fence

The native SDK parses the backend value before Sandwich receives it, so old native versions irreversibly turn `frozen` into `unknown`. Therefore this PR deliberately requires:

- Android SDK `9.8.0`;
- iOS SDK `6.15.0`;
- release order: native SDKs → Sandwich `7.13.0` → React Native/Flutter/Cordova/Capacitor/Unity.

The draft CI remains blocked on unpublished native artifacts until those releases exist. Configurator type-3 writes remain fail-closed until the complete compatibility matrix is released.

## Guardrails

- Android maps `Frozen` and keeps future values as `unknown`; its mapper test runs in PR CI and before Maven publication.
- iOS exhaustively maps `.frozen` with `@unknown default`; its static contract runs in PR CI and before `pod trunk push`.
- the contract also pins native minimum versions and release ordering in `FROZEN_ASSIGNMENT_RELEASE.md`.

## Verification

- Python frozen mapper/release-fence contract
- Android `:sandwich:testDebugUnitTest` in GitHub CI after Android 9.8.0 is published
- CocoaPods `pod lib lint --allow-warnings` in GitHub CI after iOS 6.15.0 is published
- podspec syntax, workflow validation, and `git diff --check`
